### PR TITLE
added missing info about parserOptions for ts projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ ESLint configuration file, e.g. 📄 .eslintrc.js:
 {
   ...,
   "plugins": [ ... ],
-  "extends": "@digital-h/eslint-config" <---
+  "extends": "@digital-h/eslint-config", <---
   "rules": [...]
+}
+```
+For TypeScript projects you might need to add tsconfig to parserOptions:
+```
+{
+  ...,
+  "plugins": [ ... ],
+  "extends": "@digital-h/eslint-config",
+  "parserOptions: {
+    "project: [ "./tsconfig.json" ],     <---
+  },
+  "rules": [ ... ]
 }
 ```
 


### PR DESCRIPTION
For a TS project I had to add more configs to the .eslintrc file. 
Example project was: https://github.com/digital-h-gmbh/fabucar-pro/compare/feature/new-digital-h-coding-style-guidlines?expand=1#diff-1c1900515171bb2d7eb6c67e3c9e062edd6e25ffd0579c9d0bf756daed50ffacR4-R6 

I added the missing information to the README.