### PR TITLE
add no-default-export rule to linter

### DIFF
--- a/linter/main.js
+++ b/linter/main.js
@@ -40,6 +40,7 @@ module.exports = {
         ],
       },
     ],
+    "import/no-default-export": "error"
   },
   overrides: [
     {


### PR DESCRIPTION
fixes #16 