### PR TITLE
Uses default react-native rules instead of custom overrides (new pack…

### DIFF
--- a/linter/react-native-config.js
+++ b/linter/react-native-config.js
@@ -11,9 +11,5 @@ module.exports = {
     "react/prefer-stateless-function": 2,
     "react/jsx-max-depth": [2, { max: 4 }],
     "max-lines": [1, { max: 175, skipBlankLines: true, skipComments: true }],
-    "react-native/no-unused-styles": 2,
-    "react-native/no-inline-styles": 2,
-    "react-native/no-color-literals": 2,
-    "react-native/no-single-element-style-arrays": 2,
   },
 };


### PR DESCRIPTION
As we now use `@react-native/eslint-config` instead of `@react-native-community/eslint-config`, some rules are not needed anymore