### PR TITLE
fix: Fixes ESLint config import and duplicated warning definition

### DIFF
--- a/linter/eslint.config.js
+++ b/linter/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js';
 import ts from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
-import eslint from 'eslint';
+import eslint from '@eslint/js';
 import esImport from 'eslint-plugin-import';
 import esNode from 'eslint-plugin-node';
 import unusedImports from 'eslint-plugin-unused-imports';
@@ -66,7 +66,6 @@ export default [
       eqeqeq: ['error', 'always'],
       'import/no-default-export': 'error',
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         {

--- a/linter/package.json
+++ b/linter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-h/eslint-config",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The ESLint configuration for Digital-H",
   "main": "eslint.config.js",
   "type": "module",


### PR DESCRIPTION
- Fixes the "cannot read property `recommended` of `undefined`" error when the  `eslint.configs.recommended` property gets spread into the config. 
- Removes the duplicate `@typescript-eslint/no-unused-vars` definition